### PR TITLE
Modifications to docs.humans.zone

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -97,14 +97,14 @@ module.exports = {
               path: "/dev/"
             },
             {
-              title: "Module Overview",
-              directory: true,
-              path: "/dev/x"
-            },
-            {
               title: "Humans CLI",
               directory: true,
               path: "/dev/cli"
+            },
+            {
+              title: "Module Overview",
+              directory: true,
+              path: "/dev/x"
             },
           ]
         },

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ footer:
 
 # Humans Chain
 
-**Humans** is a sovereign proof-of-stake blockchain, open-source platform, and will soon be the member of the IBC family of interconnected blockchains that comprise the Cosmos Ecosystem.
+**Humans** is a sovereign proof-of-stake next generation blockchain platform that brings together an ecosystem of stakeholders around the use of AI to create at scale.
+Soon to be a member of the **#IBCGang**, the interconnected family of blockchains that compromise the Cosmos Ecosystem.
 
-**Humans** is a next generation blockchain platform that brings together an ecosystem of stakeholders around the use of AI to create at scale. It combines a library of AI tools into a creative studio suite where users will be able to pick and choose as they bring their ideas to life. Individuals are empowered to create and own their digital likenesses, which may be used by themselves and others in the creation of any number of digital assets. The synthetic media, AI apps, and other digital assets utilize blockchain technology to generate Non-Fungible Tokens (NFTs) as a way of creating transparency, provenance, accountability, and long-term governance.  
+It combines a library of AI tools into a creative studio suite where users will be able to pick and choose as they bring their ideas to life.
+Individuals are empowered to create and own their digital likenesses, which may be used by themselves and others in the creation of any number of digital assets. The synthetic media, AI apps, and other digital assets utilize blockchain technology to generate Non-Fungible Tokens (NFTs) as a way of creating transparency, provenance, accountability, and long-term governance.  
 
 ## Humans Ecosystem
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -18,7 +18,7 @@ The **`humansd` binary is needed for running nodes** and sending IBC transfers w
 
 ### Testnet Faucet
 
-- [Discord Testnet Faucet](https://discord.com/channels/999302051538411671/1039540296540770385): Send tokens to your wallet on testnet 
+- [Discord Testnet Faucet](https://discord.com/channels/999302051538411671/1039540296540770385): Send `$HEART` tokens to your Humans wallet on the testnet 
 
 
 

--- a/dev/cli/humansd-binary.md
+++ b/dev/cli/humansd-binary.md
@@ -42,7 +42,7 @@ export PATH=<path-to-humansd>:$PATH
 
 ```bash
 # Or, copy directly to a /usr/local/bin folder
-cp humansd /usr/local/bin/humansd
+sudo    cp humansd /usr/local/bin/humansd
 ```
 
 ## Install Option 2 | Building from the Source Code
@@ -119,20 +119,3 @@ You'll need Docker to run commands that use external containers like `make proto
 
 ---
 
-## Next Steps
-
-#### Learn more about the:
-
-- [`humansd` Command-Line Interface][page-cli]
-- [Run a Full Node on Testnet][page-testnet]
-- [What's a Node Daemon?][page-node-daemon]
-- [Setup Cosmovisor][page-cosmovisor]
-- [Setup a Validator Node][page-validator]
-
-#### 
-
-[page-cosmovisor]: ../../run-nodes/testnet/cosmovisor
-[page-testnet]: ../../run-nodes/testnet
-[page-validator]: ../../run-nodes/validators
-[page-node-daemon]: ../../run-nodes/testnet/node-daemon
-[page-cli]: ./

--- a/dev/cli/humansd-cli.md
+++ b/dev/cli/humansd-cli.md
@@ -66,9 +66,19 @@ All POST commands have the following global flags:
 | --home            | string | $HOME/.humans         | Directory for config and data                                                                                  |
 | --trace           | string |                       | Print out full stack trace on errors                                                                           |
 
-<!-- ### Module Commands
+## Next Steps
 
-| **Subcommand**             | **Description**                                           |
-| -------------------------- | --------------------------------------------------------- |
-| [perp](../x/perp.md#cli)   | Perp subcommands for querying and opening positions, etc. |
-| [vpool](../x/vpool.md#cli) | Vpool subcommands for querying vpools.                    | --> |
+#### Learn more about the:
+
+- [`humansd` Command-Line Interface][page-cli]
+- [Run a Full Node on Testnet][page-node-daemon]
+- [Setup a System Daemon][page-system-daemon]
+- [Setup a Validator Node][page-validator]
+
+#### 
+
+[page-system-daemon]: ../../run-nodes/testnet/system-daemon
+[page-testnet]: ../../run-nodes/testnet
+[page-validator]: ../../run-nodes/validators
+[page-node-daemon]: ../../run-nodes/testnet/node-daemon
+[page-cli]: ./

--- a/dev/x/README.md
+++ b/dev/x/README.md
@@ -4,7 +4,7 @@ order: 0
 
 # List of Modules
 
-Here are some production-grade modules that can be used in Cosmos SDK applications, along with their respective documentation:
+Here are some production-grade Cosmos SDK modules used by Humans, along with their respective documentation:
 
 * [Auth](auth/spec/README.md) - Authentication of accounts and transactions for Cosmos SDK applications.
 * [Authz](authz/spec/README.md) - Authorization for accounts to perform actions on behalf of other accounts.

--- a/ecosystem/gov/submitting-proposals.md
+++ b/ecosystem/gov/submitting-proposals.md
@@ -6,10 +6,9 @@ This section describes how to submit governance proposals on Humans. {synopsis}
 Any HEART holder, whether bonded or unbonded, can submit proposals by sending a `TxGovProposal` transaction. This is possible using the `humansd` CLI. Each proposal type corresponds to a subcommand of `humansd tx gov submit-proposal`.
 
 #### Table of Contents
-- [⚖️ Submitting Proposals](#-submitting-proposals)
-- [⚖️Table of Contents](#table-of-contents)
-- [⚖️Proposal Types](#proposal-types)
-- [⚖️Querying a proposal](#querying-a-proposal)
+
+- [⚖️Proposal Types](#⚖%EF%B8%8F-proposal-types)
+- [⚖️Querying a proposal](#⚖%EF%B8%8F-querying-a-proposal)
 
 
 ## ⚖️ Proposal Types

--- a/learn/faq.md
+++ b/learn/faq.md
@@ -16,7 +16,7 @@ Common questions about Humans and their answers. {synopsis}
 
 ### How can I get involved?
 
-* You can try out validating our network by following the [testnet instructions](http://localhost:8080/run-nodes/testnet/).
+* You can try out running a node our network by following the [testnet instructions](/run-nodes/testnet/node-daemon.md).
 
 --- 
 ## FAQ — HEART Token
@@ -57,4 +57,4 @@ In exchange for their work, they receive revenue to support their services, ofte
 
 ### How can I become a validator?
 
-There are instructions on how to set up various kinds of nodes in the [validator docs](http://localhost:8080/run-nodes/validators/). Reach out to the team on [Discord](https://discord.gg/humansdotai) if you need assistance.
+There are instructions on how to set up various kinds of nodes in the [validator docs](/run-nodes/validators/validating-on-testnet.html). Reach out to the team on [Discord](https://discord.gg/humansdotai) if you need assistance.

--- a/run-nodes/testnet/joining-testnet.md
+++ b/run-nodes/testnet/joining-testnet.md
@@ -4,7 +4,7 @@ order: 3
 
 # 🤖 Joining Testnet
 
-Testnets are testing instances of the Humans blockchain. Testnet tokens are separate and distinct from real assets. In order to join a network, you'll need to use its corresponding version of the binary to [run a full node](./node-daemon).{synopsis}
+Testnets are testing instances of the Humans blockchain. Testnet tokens are separate and distinct from real assets. In order to join a network, you'll need to use its corresponding version of the binary to [run a full node](/dev/cli/humansd-binary.html).{synopsis}
 
 ## Available Networks
 
@@ -52,7 +52,7 @@ sudo apt upgrade --yes
 Please check for the correct version of the binary. 
 
 ::: tip
-If you have not installed `humansd`, please start with the instructions on building the [`humansd` binary](../../dev/cli/humansd-binary).
+If you have not installed `humansd`, please start with the instructions on building the [`humansd` binary](/dev/cli/humansd-binary.html).
 :::
 
 ```bash
@@ -64,7 +64,7 @@ v1.0.0
 
 ## Cosmovisor 
 
-Please follow the [`cosmovisor` setup instructions](./cosmovisor) if you haven't already.
+Please follow the [`cosmovisor` setup instructions](/run-nodes/testnet/system-daemon.html) if you haven't already.
 
 ## Init the Chain
 
@@ -173,6 +173,9 @@ Please follow the [`cosmovisor` setup instructions](./cosmovisor) if you haven't
 
 9. Request tokens from the [Discord Faucet for testnet-1](https://discord.com/channels/999302051538411671/1039540296540770385) in `#testnet-faucet` if required. Use $help to see the other functions of the faucet. Replace the address below with your own address. Please note, that current weekly request limit for the Discord Humans Faucet is 10HEART (`10000000uheart`).
 
+    :::tip
+    You need to obtain the `⚔️ Testnet` role by reacting in [ 👉🏻 | #roles](https://discord.com/channels/999302051538411671/999302052192735290) in order to see `#testnet-faucet`.
+    :::
 
 
     ```bash
@@ -193,9 +196,9 @@ Please follow the [`cosmovisor` setup instructions](./cosmovisor) if you haven't
 ## Next Steps
 
 ::: tip
-See the [validator docs](../validators) on how to participate as a validator.
+See the [validator docs](/run-nodes/validators/validating-on-testnet.html) on how to participate as a validator.
 :::
 
 For the full list of `humansd` commands, see:
-- The [`humansd` CLI introduction](../../dev/cli)
+- The [`humansd` CLI introduction](dev/cli/humansd-cli.html)
 - Humans [Module Reference](../../dev/x)

--- a/run-nodes/testnet/node-daemon.md
+++ b/run-nodes/testnet/node-daemon.md
@@ -2,7 +2,7 @@
 order: 1
 ---
 
-# 🤖 Node Daemon
+# 🤖 Full Node
 
 The main endpoint of an SDK application is the **daemon client**, otherwise known as the **full-node** client. The full-node runs the state-machine, starting from a genesis file. It connects to peers running the same client in order to receive and relay transactions, block proposals and signatures. {synopsis}
 

--- a/run-nodes/testnet/system-daemon.md
+++ b/run-nodes/testnet/system-daemon.md
@@ -2,7 +2,7 @@
 order: 2
 ---
 
-#  System Daemon
+#  🤖 System Daemon
 A daemon is a service process that runs in the background and supervises the system or provides functionality to other processes. We use daemons to ensure that the node daemon persists after restarts or crashes.{synopsis}
 ## Cosmovisor Setup (Option 1, recommended)
 
@@ -20,7 +20,7 @@ It's recommended to use Cosmovisor to run your node, however you can alternative
 Rather than having to do stressful DevOps tasks late at night, it's better if you can automate them away, and that's what Cosmovisor tries to do. It's wise to go through the `cosmovisor` setup instructions on testnet before running a full-node on mainnet. 
 
 ::: tip
-If you have not installed `humansd`, please start with the instructions on building the [`humansd` binary](../../dev/cli/humansd-binary).
+If you have not installed `humansd`, please start with the instructions on building the [`humansd` binary](/dev/cli/humansd-binary.html).
 :::
 
 ::: warning

--- a/run-nodes/validators/node-reset.md
+++ b/run-nodes/validators/node-reset.md
@@ -5,10 +5,10 @@ order: 2
 # 🤖 Resetting a validator node
 
 Instructions for validators to rebuild in the case of a chain reset. {synopsis}
-
+::: tip
 Any upcoming resets will be announced in the `#testnet-announcements` channel on [Humans Discord server](https://discord.com/channels/999302051538411671/1039540079594582026). 
 To reset your node and rejoin the testnet, please follow the steps below:
-
+:::
 ## Remove the old chain data and binary
 
 ```bash
@@ -37,4 +37,4 @@ humansd version
 
 ## Recreate the validator
 
-Follow the same steps from ["Joining Testnet"](../testnet) and ["Validating on Testnet"](./) again.
+Follow the same steps from ["Joining Testnet"](/run-nodes/testnet/joining-testnet.html) and ["Validating on Testnet"](/run-nodes/validators/validating-on-testnet.html) again.

--- a/run-nodes/validators/validating-on-testnet.md
+++ b/run-nodes/validators/validating-on-testnet.md
@@ -4,10 +4,10 @@ order: 1
 
 # 🤖 Validating on Testnet
 
-Instructions running a validator node {synopsis}
-
-As the first step, please follow the [instructions to join the testnet](../testnet).
-
+Instructions for running a validator node on the Humans testnet. {synopsis}
+::: tip
+As the first step, please follow the [instructions to join the testnet](/run-nodes/testnet/joining-testnet.html).
+:::
 ## Install the `humansd` binary
 
 Currently, the source code is not yet public, so pre-compiled binaries are required to run validator nodes.
@@ -55,7 +55,7 @@ humansd tx staking create-validator \
 --from <key-name>
 ```
 
-You can verify your node is in the validator set status by viewing the [Humans testnet block explorer](https://explorer.humans.zone/)
+You can verify your node is in the Active/Inactive validator set status by viewing the [Humans testnet block explorer](https://explorer.humans.zone/humans-testnet/staking)
 
 ### Editing the public description
 


### PR DESCRIPTION
- changed Order "Module Overview" with "Humans CLI";
- removed Next Steps from humansd-binary.md;
- changed README to humansd-cli;
- added extra text in Discord Testnet Faucet description;
- removed 2 categories from Table of Contents;
- corrected broken links in FAQ
- edit intro for humans
- corrected broken links in joining-testnet
- changed Node Daemon to Full Node
- corrected broken links in node-reset
- changed validators/README to validators/validating-on-testnet