### PR TITLE
Fixed some broken lings and removed additional spaces from commands

### DIFF
--- a/dev/cli/humansd-binary.md
+++ b/dev/cli/humansd-binary.md
@@ -42,7 +42,7 @@ export PATH=<path-to-humansd>:$PATH
 
 ```bash
 # Or, copy directly to a /usr/local/bin folder
-sudo    cp humansd /usr/local/bin/humansd
+sudo cp humansd /usr/local/bin/humansd
 ```
 
 ## Install Option 2 | Building from the Source Code

--- a/dev/cli/humansd-cli.md
+++ b/dev/cli/humansd-cli.md
@@ -11,7 +11,7 @@ An introduction to the using the `humansd` CLI along with a brief description of
 `humansd` is a command line client for the Humans network. Humans users can use `humansd` to send transactions to the Humans network and query the blockchain data.
 
 ::: tip
-See ["Humans Setup"](./humansd-binary) for instructions on installing `humansd`.
+See ["Humans Setup"](/dev/cli/humansd-binary.html) for instructions on installing `humansd`.
 :::
 
 ### Working Directory
@@ -76,7 +76,6 @@ All POST commands have the following global flags:
 
 #### 
 
-[page-system-daemon]: ../../run-nodes/testnet/system-daemon
-[page-testnet]: ../../run-nodes/testnet
+[page-system-daemon]: ../../run-nodes/testnet/system-daemon.html
 [page-validator]: ../../run-nodes/validators/validating-on-testnet.html
-[page-node-daemon]: ../../run-nodes/testnet/node-daemon
+[page-node-daemon]: ../../run-nodes/testnet/node-daemon.html

--- a/run-nodes/testnet/joining-testnet.md
+++ b/run-nodes/testnet/joining-testnet.md
@@ -200,5 +200,5 @@ See the [validator docs](/run-nodes/validators/validating-on-testnet.html) on ho
 :::
 
 For the full list of `humansd` commands, see:
-- The [`humansd` CLI introduction](dev/cli/humansd-cli.html)
+- The [`humansd` CLI introduction](/dev/cli/humansd-cli.html)
 - Humans [Module Reference](../../dev/x)


### PR DESCRIPTION
Fixed:


- sudo    cp humansd /usr/local/bin/humansd - removed extra spaces
- If you have not installed humansd, please start with the instructions on building the humansd binary. - fixed broken link
- Fixed broken links from:

Learn more about the:

Run a Full Node on Testnet
Setup a System Daemon
Setup a Validator Node