### PR TITLE
Remove typo in Discord Link

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -188,7 +188,7 @@ module.exports = {
         },
         {
           service: "discord",
-          url: "https://discorg.gg/humansdotai"
+          url: "https://discord.gg/humansdotai"
         },
         {
           service: "telegram",


### PR DESCRIPTION
changed discorg.gg to discord.gg